### PR TITLE
fix() change temperature measurement units for temperature in QT app

### DIFF
--- a/settings_pop_up.ui
+++ b/settings_pop_up.ui
@@ -49,16 +49,16 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <item>
     <property name="text">
-     <string>℉</string>
+     <string>°F</string>
     </property>
    </item>
    <item>
     <property name="text">
-     <string>℃</string>
+     <string>°C</string>
     </property>
    </item>
   </widget>

--- a/src/data_manager.cpp
+++ b/src/data_manager.cpp
@@ -52,7 +52,7 @@ void DataManager::mqtt_publish(double temp_cel, double temp_far, double pressure
     int rc;  
 
     std::stringstream mqtt_string_builder;
-    mqtt_string_builder  << "Temperature: " <<  std::fixed << std::setprecision(2) << temp_cel<<" ℃, "<< temp_far  <<   " ℉ "  << " Pressure: " <<  int(pressure) << " Pa" ;;
+    mqtt_string_builder  << "Temperature: " <<  std::fixed << std::setprecision(2) << temp_cel<<" °C, "<< temp_far  <<   " °F "  << " Pressure: " <<  int(pressure) << " Pa" ;;
 
     std::stringstream mqtt_string_raw_data;
     mqtt_string_raw_data << std::fixed << std::setprecision(2) << temp_cel << " " << temp_far  << " " << int(pressure);

--- a/src/form.cpp
+++ b/src/form.cpp
@@ -26,10 +26,10 @@ void Form::show(){
 
 void Form::takeTemp(double temp){
     currentTempUnit = set.temperature_unit;
-    if(currentTempUnit == "℃"){
+    if(currentTempUnit == "°C"){
         ui->Temp->setText(QString::number(temp));
     }
-    else if(currentTempUnit == "℉"){
+    else if(currentTempUnit == "°F"){
         ui->Temp->setText(QString::number((temp * 1.8)+32));
     }
     else{

--- a/src/form.ui
+++ b/src/form.ui
@@ -88,7 +88,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>℃</string>
+    <string>°C</string>
    </property>
   </widget>
   <widget class="QLabel" name="current_pressure_unit">

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -22,7 +22,7 @@ void Settings::generateJsonFile(){
     std::remove(json_path.c_str());
 
     pt.put("data_output_time", standart_time);
-    pt.put("temperature", "℃");
+    pt.put("temperature", "°C");
     pt.put("pressure", "Pa");
 
     boost::property_tree::write_json(json_path, pt);


### PR DESCRIPTION
previously, default Windows symbols were used for measurement units displaying in QT, which Linux can't display correctly. This issue was fixed by changing Widows symbols to UTF-8 degree sign.